### PR TITLE
Constructeur

### DIFF
--- a/QVERSIOSRC/CONSTRUCTP.CLLE
+++ b/QVERSIOSRC/CONSTRUCTP.CLLE
@@ -1,0 +1,35 @@
+      /* >>PRE-COMPILER<<                                                 */
+      /*   >>CRTCMD<<  CRTBNDCL SRCFILE(&SL/&SF) SRCMBR(&SM);             */
+      /*   >>COMPILE<<                                                    */
+      /*     >>PARM<<  OPTION(*EVENTF);                                   */
+      /*     >>PARM<<  DBGVIEW(*LIST);                                    */
+      /*     >>PARM<<  OPTIMIZE(&U0);                                     */
+      /*   >>END-COMPILE<<                                                */
+      /*   >>EXECUTE<<                                                    */
+      /* >>END-PRE-COMPILER<<                                             */
+             PGM        PARM(&NUMLOT)
+
+             DCL        VAR(&NUMLOT) TYPE(*DEC) LEN(6 0) /* Numéro de lot +
+                          à construire */
+             DCL        VAR(&NUMLOTC) TYPE(*CHAR) LEN(6) /* Numéro de lot +
+                          à construire en alpha*/
+
+             DCL        VAR(&BIBLOT) TYPE(*CHAR) LEN(10) /* Bibliothèque +
+                          du lot */
+             DCLPRCOPT  DFTACTGRP(*NO) ACTGRP(*NEW) BNDDIR(VERSIOSRV)
+
+             MONMSG     MSGID(CPF0000) EXEC(GOTO CMDLBL(ERREUR))
+
+             CHGVAR     VAR(&NUMLOTC) VALUE(&NUMLOT)
+             CHGVAR     VAR(&BIBLOT) VALUE('LOT_' *TCAT &NUMLOTC)
+             DSPFD      FILE(&BIBLOT/*ALL) TYPE(*MBRLIST) OUTPUT(*OUTFILE) +
+                          OUTFILE(QTEMP/LISTMEMBER)
+
+             CALLPRC    PRC(CONSTRUCTION_TYPE) RTNVAL(&RETOUR)
+
+
+
+ ERREUR:     DMPCLPGM
+             CALLPRC    PRC(GEST_ERREUR)
+
+ FIN:        ENDPGM

--- a/QVERSIOSRC/CONSTRUTYP.SQLRPGLE
+++ b/QVERSIOSRC/CONSTRUTYP.SQLRPGLE
@@ -1,0 +1,65 @@
+      * >>PRE-COMPILER<<                                              */
+      *   >>CRTCMD<<  CRTSQLRPGI SRCFILE(&SL/&SF) SRCMBR(&SM);        */
+      *   >>COMPILE<<                                                 */
+      *     >>PARM<<  OBJ(&LI/&OB);                                   */
+      *     >>PARM<<  OBJTYPE(*MODULE);                               */
+      *     >>PARM<<  OPTION(*EVENTF);                                */
+      *     >>PARM<<  RPGPPOPT(*LVL2);                                */
+      *     >>PARM<<  CLOSQLCSR(*ENDACTGRP);                          */
+      *     >>PARM<<  DATFMT(*ISO);                                   */
+      *     >>PARM<<  TIMFMT(*ISO);                                   */
+      *     >>PARM<<  COMPILEOPT(&U0);                                */
+      *   >>END-COMPILE<<                                             */
+      *   >>EXECUTE<<                                                 */
+      * >>END-PRE-COMPILER<<                                          */
+       ctl-opt nomain;
+      /copy qversiosrc,cpyctlstm
+
+       dcl-proc ordonnanceur_construction export ;
+       dcl-pi ordonnanceur_construction like(sqlcode) end-pi;
+       dcl-s retour like(sqlcode);
+       dcl-ds ds_listmember extname('LISTMEMBER') End-Ds;
+
+
+         exec sql DECLARE C_ordre CURSOR FOR SELECT Type_source
+                                               FROM ORDONNANCEMENT
+                                               ORDER BY ordre;
+
+         exec sql open c_ordre;
+
+         exec sql FETCH FROM C_ORDRE INTO :g_type_source;
+
+         dow sqlcode=0;
+           exec sql DECLARE C_source CURSOR FOR SELECT Type_source
+                                               FROM LISTMEMBER
+                                               where MLSEU2=:g_type_source;
+
+           exec sql open c_source;
+
+           exec sql FETCH FROM C_source INTO :ds_listmember;
+           dow sqlcode=0;
+
+             creation( ds_listmember
+                      :ds_parameter_environnement);
+             exec sql FETCH FROM C_source INTO :ds_listmember;
+           enddo;
+
+
+
+           exec sql FETCH FROM C_ORDRE INTO :g_type_source;
+         EndDo;
+
+
+
+
+         return retour;
+
+       end-proc;
+
+
+
+
+
+
+
+

--- a/QVERSIOSRC/CPYCTLSTM.SQLRPGLE
+++ b/QVERSIOSRC/CPYCTLSTM.SQLRPGLE
@@ -1,0 +1,3 @@
+       ctl-opt option(*nodebugio:*srcstmt:*NOUNREF) CCSIDCVT(*LIST);
+       ctl-opt dftactgrp(*no) datedit(*ymd);
+       ctl-opt bnddir('MIRUS_BND':'SERVICE');

--- a/QVERSIOSRC/ORDONNANCE.SQL
+++ b/QVERSIOSRC/ORDONNANCE.SQL
@@ -1,0 +1,39 @@
+    --* >>PRE-COMPILER<<                                              */
+    --*   >>CRTCMD<<  RUNSQLSTM SRCFILE(&SL/&SF) SRCMBR(&SM);         */
+    --*   >>IMPORTANT<<                                               */
+    --*     >>PARM<<  COMMIT(*NONE);                                  */
+    --*     >>PARM<<  NAMING(*SQL);                                   */
+    --*     >>PARM<<  DFTRDBCOL(&SL);                                 */
+    --*   >>END-IMPORTANT<<                                           */
+    --*   >>EXECUTE<<                                                 */
+    --* >>END-PRE-COMPILER<<                                          */
+--DROP TABLE ORDONNANCE;
+
+CREATE TABLE ORDONNANCE(
+    UUID ROWID GENERATED ALWAYS,
+    ordre DEC(10) NOT NULL DEFAULT 0,
+    Type_source FOR COLUMN TYPSRC CHAR(10) CCSID 1147 NOT NULL DEFAULT '')
+    RCDFMT ORDONNANCF;
+
+LABEL ON TABLE ORDONNANCE IS 'VERSIONNING - ORDONNANCEMENT';
+
+LABEL ON COLUMN ORDONNANCE(
+                            UUID IS 'Identifiant',
+                            ordre IS 'Ordonnancement',
+                            Type_source IS 'Type                de source');
+
+LABEL ON COLUMN ORDONNANCE(
+                             UUID TEXT IS 'Identifiant',
+                             ordre TEXT IS 'Ordre des compilatations par type',
+                             Type_source TEXT IS 'Type de source');
+
+GRANT SELECT ON ORDONNANCE TO PUBLIC;
+
+GRANT ALTER,
+      DELETE,
+      INDEX,
+      INSERT,
+      REFERENCES,
+      SELECT,
+      UPDATE ON ORDONNANCE TO QPGMR
+    WITH GRANT OPTION;

--- a/QVERSIOSRC/ORDONNANCE.SQL
+++ b/QVERSIOSRC/ORDONNANCE.SQL
@@ -1,12 +1,12 @@
-    --* >>PRE-COMPILER<<                                              */
-    --*   >>CRTCMD<<  RUNSQLSTM SRCFILE(&SL/&SF) SRCMBR(&SM);         */
-    --*   >>IMPORTANT<<                                               */
-    --*     >>PARM<<  COMMIT(*NONE);                                  */
-    --*     >>PARM<<  NAMING(*SQL);                                   */
-    --*     >>PARM<<  DFTRDBCOL(&SL);                                 */
-    --*   >>END-IMPORTANT<<                                           */
-    --*   >>EXECUTE<<                                                 */
-    --* >>END-PRE-COMPILER<<                                          */
+    -->>PRE-COMPILER<<                                              */
+    --  >>CRTCMD<<  RUNSQLSTM SRCFILE(&SL/&SF) SRCMBR(&SM);         */
+    --  >>IMPORTANT<<                                               */
+    --    >>PARM<<  COMMIT(*NONE);                                  */
+    --    >>PARM<<  NAMING(*SQL);                                   */
+    --    >>PARM<<  DFTRDBCOL(&SL);                                 */
+    --  >>END-IMPORTANT<<                                           */
+    --  >>EXECUTE<<                                                 */
+    -->>END-PRE-COMPILER<<                                          */
 --DROP TABLE ORDONNANCE;
 
 CREATE TABLE ORDONNANCE(

--- a/QVERSIOSRC/STRPREPRCP.CLLE
+++ b/QVERSIOSRC/STRPREPRCP.CLLE
@@ -1,0 +1,10 @@
+             PGM        PARM(&DS_LISTMEMBER &DS_PARAM_ENVIR)
+
+             STRPREPRC  USESRCFILE(&BIBSRC/&SRCFILE) USESRCMBR(&MEMBERSRC) +
+                          LIB(&LI) OBJ(&OB) TYPECODE(&TY) SRCLIB(&SL) +
+                          SRCFILE(&SF) SRCMBR(&SM) TESTLIB(&TL) +
+                          TESTOBJ(&TO) TGTRLS(&TR) FRMSRCLIB(&FL) +
+                          FRMSRCFILE(&FF) FRMSRCMBR(&FM) USER0(&U0) +
+                          USER1(&U1) USER2(&U2) USER3(&U3) USER4(&U4) +
+                          USER5(&U5) USER6(&U6) USER7(&U7) USER8(&U8) +
+                          USER9(&U9)

--- a/QVERSIOSRC/VERSIOSRV.BND
+++ b/QVERSIOSRC/VERSIOSRV.BND
@@ -1,0 +1,15 @@
+    /* >>PRE-COMPILER<<                                              */
+    /*   >>CRTCMD<<  CRTSRVPGM SRCFILE(&SL/&SF) SRCMBR(&SM);         */
+    /*   >>LINK<<                                                    */
+    /*     >>PARM<<  SRVPGM(&LI/&SM);                                */
+    /*     >>PARM<<  MODULE(&LI/CONSTRUTYP);                         */
+    /*     >>PARM<<  BNDDIR(SERVICE);                                */
+    /*     >>PARM<<  DETAIL(*FULL);                                  */
+    /*     >>PARM<<  ALWLIBUPD(*YES);                                */
+    /*   >>END-LINK<<                                                */
+    /*   >>EXECUTE<<                                                 */
+    /* >>END-PRE-COMPILER<<                                          */
+
+             STRPGMEXP  PGMLVL(*CURRENT) SIGNATURE('VERSIONNING_0.1')
+                EXPORT     SYMBOL(ordonnanceur_construction)
+             ENDPGMEXP


### PR DESCRIPTION
Création des ébauches de fonction de construction. A tester et corriger.
Problème dans la logique de création de départ.
Comment ordonner correctement les création:

1. PF
2. LF
3. SQL
4. DSPF
5. PRTF
6. SRVPGM-->préalable Module
7. PGM

Soit le traitement ordonne correctement les types de source à compiler, le problème se pose au niveau des programmes de service, soit le développeur conçoit un script de build et le lance dans ce cas, ce traitement devient inutile Rdi fournissant déjà un outil simple de construction. 